### PR TITLE
README: Missing important detail concerning 256 colorspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the following to your `~/.vimrc` file.
     cp base16/colors/*.vim .
     
 ## 265 colorspace 
-If using a Base16 terminal theme designed to keep the 16 ANSI colors intact (a "256" variation) and have sucessfully modified your 256 colorspace with [base16-shell](https://github.com/chriskempson/base16-shell) you'll need to add the following to your `~/.vimrc`.
+If using a Base16 terminal theme designed to keep the 16 ANSI colors intact (a "256" variation) and have sucessfully modified your 256 colorspace with [base16-shell](https://github.com/chriskempson/base16-shell) you'll need to add the following to your `~/.vimrc` **before** the colorsheme declaration.
 
     let base16colorspace=256  " Access colors present in 256 colorspace
 


### PR DESCRIPTION
In the README, an important detail is missing from the 256 colorspace section.

in the vimrc file, the base16colorspace declaration line must be placed before the colorsheme declaration, like so:

let base16colorspace=256  " Access colors present in 256 colorspace
colorsheme base16-default
I'm running vim inside iTerm2 with the "256" variation and it took me a while to figure out why the colors where all mixed up in my terminal vim.
