### PR TITLE
Minor README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the following to your `~/.vimrc` file.
     git clone git://github.com/chriskempson/base16-vim.git base16
     cp base16/colors/*.vim .
     
-## 265 colorspace 
+## 256 colorspace 
 If using a Base16 terminal theme designed to keep the 16 ANSI colors intact (a "256" variation) **and** have sucessfully modified your 256 colorspace with [base16-shell](https://github.com/chriskempson/base16-shell) you'll need to add the following to your `~/.vimrc` **before** the colorsheme declaration.
 
     let base16colorspace=256  " Access colors present in 256 colorspace


### PR DESCRIPTION
This fixes a minor `README.md` typo (from ‘265’ colours to ‘256’).
