### PR TITLE
Replace 'Bundle' with 'Plugin' in Vundle docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To use the dark theme ensure `set background=dark` is present in your `~/.vimrc`
 Add `colorscheme base16-default` to your `~/.vimrc`.
 
 ### Vundle
-Add the following to your `~/.vimrc` file and run `BundleInstall` in Vim.
+Add the following to your `~/.vimrc` file and run `PluginInstall` in Vim.
 
-    Bundle 'chriskempson/base16-vim'
+    Plugin 'chriskempson/base16-vim'
     
 ### Pathogen
 


### PR DESCRIPTION
This reflects recent changes to Vundle:
https://github.com/gmarik/Vundle.vim/commit/bf70a158c5db74b5c1415713976d41943788d0d1
