### PR TITLE
Fix: 'colourtest' -> 'colortest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If using a Base16 terminal theme designed to keep the 16 ANSI colors intact (a "
 This will cause vim to access the colours in the modified 256 colorspace. Please **do not** enable this simply because you have a 256 color terminal as this will cause colors to be displayed incorrectly. 
 
 ## Troubleshooting
-There is a script to help troubleshoot colour issues caled `colourtest` available in the [Base16 Shell](https://github.com/chriskempson/base16-shell) repository.
+There is a script to help troubleshoot colour issues caled `colortest` available in the [Base16 Shell](https://github.com/chriskempson/base16-shell) repository.
 
 ### Green line numbers
 ![green line numbers screenshot](https://raw.github.com/chriskempson/base16-vim/master/without-base16colorspace-256-with-256-terminal-theme.png)
@@ -50,4 +50,4 @@ If your Vim looks like the above image you are using a 256 terminal theme withou
 ### Blue line numbers
 ![blue line numbers screenshot](https://raw.github.com/chriskempson/base16-vim/master/with-base16colorspace-256-without-base16-shell.png)
 
-If your Vim looks like the above image you are setting `let base16colorspace=256` in your `~/.vimrc` but either not running [Base16 Shell](https://github.com/chriskempson/base16-shell) or [Base16 Shell](https://github.com/chriskempson/base16-shell) is not working for your terminal. Either ensure [Base16 Shell](https://github.com/chriskempson/base16-shell) is working by running the `colourtest` available in the [Base16 Shell](https://github.com/chriskempson/base16-shell) repository or not setting `let base16colorspace=256` in your `~/.vimrc`.
+If your Vim looks like the above image you are setting `let base16colorspace=256` in your `~/.vimrc` but either not running [Base16 Shell](https://github.com/chriskempson/base16-shell) or [Base16 Shell](https://github.com/chriskempson/base16-shell) is not working for your terminal. Either ensure [Base16 Shell](https://github.com/chriskempson/base16-shell) is working by running the `colortest` available in the [Base16 Shell](https://github.com/chriskempson/base16-shell) repository or not setting `let base16colorspace=256` in your `~/.vimrc`.


### PR DESCRIPTION
The script appears to be named in the American style in the repo (https://github.com/chriskempson/base16-shell/blob/master/colortest)