### PR TITLE
Background variable in base16-vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ For terminal Vim (non-gui) please ensure you are using a base16 terminal theme.
 * [iTerm2](https://github.com/chriskempson/base16-iterm2)
 
 ## Installation
-To use the dark theme ensure `set background=dark` is present in your `~/.vimrc` file. Otherwise Vim will use the light variation by default.
 
 Add `colorscheme base16-default-dark` to your `~/.vimrc`.
 

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -8,7 +8,7 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has('gui_running')
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-{{scheme-slug}}.".&background.".sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16-{{scheme-slug}}.sh"
   endif
 endif
 


### PR DESCRIPTION
From the notes in the deprecated base16-builder and the fact that the schemes no longer have a name.dark.ext format, I believe you removed the light/dark background variable in favor of separate files. If so, this patch fixes the auto-loading of base16-shell files in the base16-vim schemes.