### PR TITLE
Fixes :terminal colors in Neovim.

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -59,6 +59,32 @@ else
   let s:cterm0F = "14"
 endif
 
+" Neovim terminal colours
+if has("nvim")
+  let g:terminal_color_0 =  "#{{base00-hex}}"
+  let g:terminal_color_1 =  "#{{base08-hex}}"
+  let g:terminal_color_2 =  "#{{base0B-hex}}"
+  let g:terminal_color_3 =  "#{{base0A-hex}}"
+  let g:terminal_color_4 =  "#{{base0D-hex}}"
+  let g:terminal_color_5 =  "#{{base0E-hex}}"
+  let g:terminal_color_6 =  "#{{base0C-hex}}"
+  let g:terminal_color_7 =  "#{{base05-hex}}"
+  let g:terminal_color_8 =  "#{{base03-hex}}"
+  let g:terminal_color_9 =  "#{{base09-hex}}"
+  let g:terminal_color_10 = "#{{base01-hex}}"
+  let g:terminal_color_11 = "#{{base02-hex}}"
+  let g:terminal_color_12 = "#{{base04-hex}}"
+  let g:terminal_color_13 = "#{{base06-hex}}"
+  let g:terminal_color_14 = "#{{base0F-hex}}"
+  let g:terminal_color_15 = "#{{base07-hex}}"
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_7
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+endif
+
 " Theme setup
 hi clear
 syntax reset


### PR DESCRIPTION
This fixes #69 if the vim themes files are built with https://github.com/chriskempson/base16-builder-php. The effect is identical to  chriskempson/base16-builder#346, but for the new 0.8 builder spec.

As noted in #69, Neovim has an embedded terminal emulator. Neovim can also operate in truecolor mode. This mode is now set in neovim with option
```vim
set termguicolors
```
If this option is set, the colours used in neovim's embedded terminal need to be defined in the theme file. The PR includes a check for whether the user is running neovim, such that regular vim users will not be affected.