### PR TITLE
Fixed color order

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -113,6 +113,7 @@ fun <sid>hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
 endfun
 
 " Vim editor colors
+call <sid>hi("Normal",        s:gui05, s:gui00, s:cterm05, s:cterm00, "", "")
 call <sid>hi("Bold",          "", "", "", "", "bold", "")
 call <sid>hi("Debug",         s:gui08, "", s:cterm08, "", "", "")
 call <sid>hi("Directory",     s:gui0D, "", s:cterm0D, "", "", "")
@@ -140,7 +141,6 @@ call <sid>hi("Title",         s:gui0D, "", s:cterm0D, "", "none", "")
 call <sid>hi("Conceal",       s:gui0D, s:gui00, s:cterm0D, s:cterm00, "", "")
 call <sid>hi("Cursor",        s:gui00, s:gui05, s:cterm00, s:cterm05, "", "")
 call <sid>hi("NonText",       s:gui03, "", s:cterm03, "", "", "")
-call <sid>hi("Normal",        s:gui05, s:gui00, s:cterm05, s:cterm00, "", "")
 call <sid>hi("LineNr",        s:gui03, s:gui01, s:cterm03, s:cterm01, "", "")
 call <sid>hi("SignColumn",    s:gui03, s:gui01, s:cterm03, s:cterm01, "", "")
 call <sid>hi("StatusLine",    s:gui04, s:gui02, s:cterm04, s:cterm02, "none", "")


### PR DESCRIPTION
The order in which the colors are getting set seems to play a role.

From :h cterm-colors:
<	When setting the "ctermbg" color for the Normal group, the
	'background' option will be adjusted automatically.  This causes the
	highlight groups that depend on 'background' to change!  This means
	you should set the colors for Normal first, before setting other
	colors.

In my case I had base16-tomorrow installed with airline and the whitespace warning of airline was hard to read. It turned out that this was the root cause for that: I had :set background=light before :colorscheme base16-tomorrow in my vimrc and :verbose set background? revealed, that base16-tomorrow.vim had reset it back to dark, even though it does not contain any set background-command.