### PR TITLE
Better python support

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -292,6 +292,8 @@ call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
 " Python highlighting
 call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")
 call <sid>hi("pythonRepeat",    s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonInclude",   s:gui0E, "", s:cterm0E, "", "", "")
+call <sid>hi("pythonStatement", s:gui0E, "", s:cterm0E, "", "", "")
 
 " Ruby highlighting
 call <sid>hi("rubyAttribute",               s:gui0D, "", s:cterm0D, "", "", "")


### PR DESCRIPTION
Use color base0E for keywords. `import`, `class` and `def` are python keywords. On the image, left is before and right is after the changes
![python](https://cloud.githubusercontent.com/assets/1058504/26760737/76047edc-4920-11e7-9255-5e1cdc1f6558.png)
