### PR TITLE
Fixes nvim terminal colors

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -70,15 +70,15 @@ if has("nvim")
   let g:terminal_color_6 =  "#{{base0C-hex}}"
   let g:terminal_color_7 =  "#{{base05-hex}}"
   let g:terminal_color_8 =  "#{{base03-hex}}"
-  let g:terminal_color_9 =  "#{{base09-hex}}"
-  let g:terminal_color_10 = "#{{base01-hex}}"
-  let g:terminal_color_11 = "#{{base02-hex}}"
-  let g:terminal_color_12 = "#{{base04-hex}}"
-  let g:terminal_color_13 = "#{{base06-hex}}"
-  let g:terminal_color_14 = "#{{base0F-hex}}"
+  let g:terminal_color_9 =  "#{{base08-hex}}"
+  let g:terminal_color_10 = "#{{base0B-hex}}"
+  let g:terminal_color_11 = "#{{base0A-hex}}"
+  let g:terminal_color_12 = "#{{base0D-hex}}"
+  let g:terminal_color_13 = "#{{base0E-hex}}"
+  let g:terminal_color_14 = "#{{base0C-hex}}"
   let g:terminal_color_15 = "#{{base07-hex}}"
   let g:terminal_color_background = g:terminal_color_0
-  let g:terminal_color_foreground = g:terminal_color_7
+  let g:terminal_color_foreground = g:terminal_color_5
   if &background == "light"
     let g:terminal_color_background = g:terminal_color_7
     let g:terminal_color_foreground = g:terminal_color_2


### PR DESCRIPTION
Some terminal colors were not correct.
Colors updated based on base16-shell:
https://github.com/chriskempson/base16-shell/blob/d2ca2dc81c427a9e03ec0ade8254af9743611972/templates/default.mustache#L6-L29