### PR TITLE
Added java "new" operator highlight

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -378,7 +378,7 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
-" Java Operator color
+" Java highlighting
 call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
 
 " Remove functions

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -378,6 +378,9 @@ call <sid>hi("StartifySelect",   s:gui0C, "", s:cterm0C, "", "", "")
 call <sid>hi("StartifySlash",    s:gui03, "", s:cterm03, "", "", "")
 call <sid>hi("StartifySpecial",  s:gui03, "", s:cterm03, "", "", "")
 
+" Java Operator color
+call <sid>hi("javaOperator",     s:gui0D, "", s:cterm0D, "", "", "")
+
 " Remove functions
 delf <sid>hi
 


### PR DESCRIPTION
Currently java `new` operator is not highlighted. Yes, we can set the highlight in `vimrc`, but I believe it should be highlighted without any user intervention.