### PR TITLE
Modify PHP method color

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -333,6 +333,7 @@ call <sid>hi("NERDTreeExecFile",  s:gui05, "", s:cterm05, "", "", "")
 call <sid>hi("phpMemberSelector",  s:gui05, "", s:cterm05, "", "", "")
 call <sid>hi("phpComparison",      s:gui05, "", s:cterm05, "", "", "")
 call <sid>hi("phpParent",          s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("phpMethodsVar",      s:gui0C, "", s:cterm0C, "", "", "")
 
 " Python highlighting
 call <sid>hi("pythonOperator",  s:gui0E, "", s:cterm0E, "", "", "")


### PR DESCRIPTION
I found that PHP methods are the same color as classes and some other things. This might not affect many people but for my case where I pass class names to functions frequently, it makes distinguishing them a little harder so I would like to add more contrast.

I assume I modify just template and the rest are generated by some other process. I hope the color is okay, it works for me but if you want it changed, let me know.

eg:
```php
class Foo
{
    public function bar()
    {
        $this->method(Foo::class);
    }
}
```