### PR TITLE
Let Base16hi optionally omit `attr` and `guisp`

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -129,7 +129,11 @@ syntax reset
 let g:colors_name = "base16-{{scheme-slug}}"
 
 " Highlighting function
-function! g:Base16hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
+" Optional variables are attributes and guisp
+function! g:Base16hi(group, guifg, guibg, ctermfg, ctermbg, ...)
+	let a:attr = get(a:, 1, "")
+	let a:guisp = get(a:, 2, "")
+
   if a:guifg != ""
     exec "hi " . a:group . " guifg=#" . a:guifg
   endif


### PR DESCRIPTION
Now users can omit the last two args to `Base16hi`. This is pretty useful if you have a decent amount of overrides specified in your vimrc. I was too lazy, but we can also remove the `""` passed in
in the rest of the template making it cleaner.