### PR TITLE
Change all quotes to double quotes.

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -8,7 +8,7 @@
 " :colorscheme works in terminals supported by base16-shell scripts
 " User must set this variable in .vimrc
 "   let g:base16_shell_path=base16-builder/output/shell/
-if !has('gui_running')
+if !has("gui_running")
   if exists("g:base16_shell_path")
     execute "silent !/bin/sh ".g:base16_shell_path."/base16-{{scheme-slug}}.sh"
   endif
@@ -69,7 +69,7 @@ let s:cterm0D        = "04"
 let g:base16_cterm0D = "04"
 let s:cterm0E        = "05"
 let g:base16_cterm0E = "05"
-if exists('base16colorspace') && base16colorspace == "256"
+if exists("base16colorspace") && base16colorspace == "256"
   let s:cterm01        = "18"
   let g:base16_cterm01 = "18"
   let s:cterm02        = "19"
@@ -121,7 +121,7 @@ if has("nvim")
     let g:terminal_color_background = g:terminal_color_7
     let g:terminal_color_foreground = g:terminal_color_2
   endif
-elseif has('terminal')
+elseif has("terminal")
   let g:terminal_ansi_colors = [
         \ "#{{base00-hex}}",
         \ "#{{base08-hex}}",


### PR DESCRIPTION
default.mustache was previously 90% double quotes.
It is now consistently using double quotes. this makes diffs easier if
everyone chooses to use double quotes from now on.