### PR TITLE
Add neovim LSP styling for diagnostics

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -332,6 +332,12 @@ call <sid>hi("jsGlobalNodeObjects", s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("jsExceptions",        s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("jsBuiltins",          s:gui0A, "", s:cterm0A, "", "", "")
 
+" LSP highlighting
+call <sid>hi("LspDiagnosticsDefaultError", s:gui08, "", s:cterm08, "", "", "")
+call <sid>hi("LspDiagnosticsDefaultWarning", s:gui09, "", s:cterm09, "", "", "")
+call <sid>hi("LspDiagnosticsDefaultHnformation", s:gui05, "", s:cterm05, "", "", "")
+call <sid>hi("LspDiagnosticsDefaultHint", s:gui03, "", s:cterm03, "", "", "")
+
 " Mail highlighting
 call <sid>hi("mailQuoted1",  s:gui0A, "", s:cterm0A, "", "", "")
 call <sid>hi("mailQuoted2",  s:gui0B, "", s:cterm0B, "", "", "")


### PR DESCRIPTION
Neovim is coming out with built-in support for language servers (v0.5). This addition sets default colors for the diagnostics output (errors and warnings and such provided by the language server). 

Attached is a picture of rust code using the summerfruit light theme in neovim with these changes applied.
![screenshot-2021-Jan-20--07-57-08](https://user-images.githubusercontent.com/834265/105180902-2475f980-5af9-11eb-81c4-0fa5207bbe0f.png)
