### PR TITLE
Fix broken horizon-terminal-* slugs

### DIFF
--- a/colors/base16-horizon-terminal-dark.vim
+++ b/colors/base16-horizon-terminal-dark.vim
@@ -10,7 +10,7 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-dark.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-terminal-dark.sh"
   endif
 endif
 
@@ -145,7 +145,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "base16-horizon-dark"
+let g:colors_name = "base16-horizon-terminal-dark"
 
 " Highlighting function
 " Optional variables are attributes and guisp

--- a/colors/base16-horizon-terminal-light.vim
+++ b/colors/base16-horizon-terminal-light.vim
@@ -10,7 +10,7 @@
 "   let g:base16_shell_path=base16-builder/output/shell/
 if !has("gui_running")
   if exists("g:base16_shell_path")
-    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-light.sh"
+    execute "silent !/bin/sh ".g:base16_shell_path."/base16-horizon-terminal-light.sh"
   endif
 endif
 
@@ -145,7 +145,7 @@ endif
 " Theme setup
 hi clear
 syntax reset
-let g:colors_name = "base16-horizon-light"
+let g:colors_name = "base16-horizon-terminal-light"
 
 " Highlighting function
 " Optional variables are attributes and guisp


### PR DESCRIPTION
The base16-horizon-terminal-dark theme previously referred to base16-horizon-dark instead, and similarly for -light. This is definitely incorrect for the `g:colors_name` variable, as that should match the name of the colorscheme. I'm not sure whether this was intentional for base16-shell purposes as I don't use that software so haven't tested it, but if not then probably the root cause is an error in whatever .yaml was fed to the template to generate these files (I looked briefly and couldn't find the source of those).