### PR TITLE
Update README.md to fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supports graphical Vim and console Vim.
 ## Terminal Themes
 For terminal Vim (non-gui) please ensure you are using a base16 terminal theme.
 
-* [iTerm2](base16-iterm2)
+* [iTerm2](https://github.com/chriskempson/base16-iterm2)
 
 ## Installation
 


### PR DESCRIPTION
Fixes the link to base16-iTerm2, which got broken in commit f81ae34